### PR TITLE
SD-0001: Ugaszenie pozaru.

### DIFF
--- a/src/pl/javastart_zadania/PhoneBook/TeleBook.java
+++ b/src/pl/javastart_zadania/PhoneBook/TeleBook.java
@@ -3,6 +3,7 @@ package pl.javastart_zadania.PhoneBook;
 import java.util.HashMap;
 import java.util.Map;
 
+//Komenatarz do testowania hotfixu -- gitflow
 public class TeleBook {
     Map<String, Contact> contacts = new HashMap<>();
 


### PR DESCRIPTION
Poprawka ma na celu ugeszanie pozaru.

Diagnoza:

W przypadku gdy uzytkownik nie ma wpisu w tabeli XX poniewaz jego konto zostalo utworzone przed 2016 w momencie gdy dokonuje wplaty leci NPE.

Implementacja:

Dodanie standardowego nullcheck.

Test:

1. Zaloguj sie na login: blabla.
2. Wcisnij to i to.
3. Zweryfikuj czy nie ma bledu.